### PR TITLE
[신성오] sprint3

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,29 +10,32 @@
   <!-- header 시작 -->
   <header class ="header">
     <a href= "'/'">
-      <img src="../images/Property 1=sm.png" alt="판다마켓" class="header_img"></a>
-    <a href="login.html" target="_blank" class="login_btn">
-      <img src="../images/btn_small.png" alt="btn_small.png" class="login">
+      <img src="./images/Property 1=sm.png" alt="판다마켓" class="header_img">
+    </a>
+    <a href="login.html" target="_self" class="login_btn">
+      <img src="./images/btn_small.png" alt="btn_small.png" class="login">
     </a>
   </header>
   <main>
     <!-- 일상의 모든 물건-->
     <section class="top_banner">
       <div class="banner_1">
-        <div class="banner-text">
+        <div class="banner_text">
           일상의 모든 물건을<br>
-          거래해보세요
+          거래해보세요<br>
+          <a href="/items" target="_self" class="more_btn">
+            <div class="showmorebtn">
+              구경하러 가기
+            </div>
         </div>
-      <a href="/items" target="blank" class="more_btn">
-        <img src="../images/btn_large.png" alt="btn_large.png" class="morebtn">
       </a>
-        <img src="../images/Img_home_top.png" class="topbannerimg">
+        <img src="./images/Img_home_top.png" class="topbannerimg">
       </div>
     </section>
     <section class="paragraph">
       <!-- 인기상품 -->
       <div class ="para1">
-        <img src="../images/Img_home_01.png" alt="para1-img" class="pimg1">
+        <img src="./images/Img_home_01.png" alt="para1-img" class="pimg1">
          <div class="para-text">
           <h5 class="smtx">Hot item</h5><br>
           <h3 class="smtx2">인기 상품을<br>
@@ -48,11 +51,11 @@
            상품을 검색하세요</h3>
            <p class="smtx3">구매하고 싶은 물품은 검색해서 쉽게 찾아보세요</p>
           </div>
-      <img src="../images/Img_home_02.png" alt="para2-img" class="pimg2">  
+      <img src="./images/Img_home_02.png" alt="para2-img" class="pimg2">  
       </div>
       <!-- 판매를원하는 -->
       <div class="para3">
-        <img src="../images/Img_home_03.png" alt="para3-img" class="pimg3">
+        <img src="./images/Img_home_03.png" alt="para3-img" class="pimg3">
         <div class="para-text">
          <h5 class="smtx">Register</h5>
          <h3 class="smtx2">판매를 원하는<br>
@@ -68,7 +71,7 @@
          믿을 수 있는<br>
          판다마켓 중고거래
         </div>
-        <img src="../images/Img_home_bottom.png" class="bot_img">
+        <img src="./images/Img_home_bottom.png" class="bot_img">
       </div>
     </section>
   </main>
@@ -81,10 +84,10 @@
         <a href="/FAQ">FAQ</a>
       </div>
       <span class="sns-icon">
-        <img src="../images/ic_facebook.png" alt="페이스북">
-        <img src="../images/ic_twitter.png" alt="트위터">
-        <img src="../images/ic_youtube.png" alt="유튜브">
-        <img src="../images/ic_instagram.png" alt="인스타그램">
+        <img src="./images/ic_facebook.png" alt="페이스북">
+        <img src="./images/ic_twitter.png" alt="트위터">
+        <img src="./images/ic_youtube.png" alt="유튜브">
+        <img src="./images/ic_instagram.png" alt="인스타그램">
       </span>
     </div>
   </footer>

--- a/login.css
+++ b/login.css
@@ -7,8 +7,16 @@ body{
   box-sizing: border-box;
   width: 100%;
   margin: 0 auto;
+  
 }
 
+@media (max-width: 767px) and (min-width: 375px) {
+  body {
+    width: calc(100% - 32px);
+    padding: 0 16px;
+  }
+
+}
 
 .loginpage {
   width: 80%;
@@ -23,14 +31,13 @@ body{
   flex-direction: column;
   gap: 25px;
   padding: 0;
-
-  
 }
 
 .loginimg {
-  width: 396px;
-  height: 132px;
-  margin: 0 auto 20px;
+  width: auto;
+  height: 100%;
+  margin: 0 auto 10px;
+  max-width: 100%;
 }
 
 .loginform {
@@ -57,11 +64,12 @@ body{
   font-size: 16px;
   width: 100%;
   height: 48px;
+  box-sizing: border-box;
   border: 1px solid #ddd;
   border-radius: 12px;
   background-color: #f3f4f6;
   outline: none;
-  padding: 0 12px;
+  padding: 0 16px;
 }
 
 .pswdform {
@@ -101,4 +109,5 @@ body{
   padding: 20px auto;
   gap: 10px;
   font-size: 16px;
+  box-sizing: border-box;
 }

--- a/login.html
+++ b/login.html
@@ -9,7 +9,7 @@
 <body>
   <div class="loginpage">
     <div class="text-para">
-     <img src="../images/logo.png" alt=loginimg class="loginimg">
+     <img src="./images/logo.png" alt=loginimg class="loginimg">
      <form class="loginform">
       <!-- 이메일 적는 곳 시작-->
       <label class="emailform">
@@ -21,17 +21,17 @@
         비밀번호
         <input type="text" name="userPassword" placeholder="password" class="innertext">
       </label>
-      <button class="login-btn">로그인</button>
+      <button type="submit" class="login-btn">로그인</button>
      </form>
      <!-- 간편 로그인 칸-->
     <div class="easylogin">
       <span>간편 로그인 하기</span>
       <div class="el-icon">
         <a href="https://www.google.com">
-          <img src="../images/Component 2.png">
+          <img src="./images/Component 2.png">
         </a>
         <a href="https://www.kakaocorp.com/page">
-          <img src="../images/Component 3.png">
+          <img src="./images/Component 3.png">
         </a>
       </div>
     </div>

--- a/market.html
+++ b/market.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>판다마켓</title> 
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <!-- header 시작 -->
+  <header class ="header">
+    <a href= "'/'">
+      <img src="./images/Property 1=sm.png" alt="판다마켓" class="header_img">
+    </a>
+    <a href="login.html" target="_self" class="login_btn">
+      <img src="./images/btn_small.png" alt="btn_small.png" class="login">
+    </a>
+  </header>
+  <main>
+    <!-- 일상의 모든 물건-->
+    <section class="top_banner">
+      <div class="banner_1">
+        <div class="banner_text">
+          일상의 모든 물건을<br>
+          거래해보세요<br>
+          <a href="/items" target="_self" class="more_btn">
+            <div class="showmorebtn">
+              구경하러 가기
+            </div>
+        </div>
+      </a>
+        <img src="./images/Img_home_top.png" class="topbannerimg">
+      </div>
+    </section>
+    <section class="paragraph">
+      <!-- 인기상품 -->
+      <div class ="para1">
+        <img src="./images/Img_home_01.png" alt="para1-img" class="pimg1">
+         <div class="para-text">
+          <h5 class="smtx">Hot item</h5><br>
+          <h3 class="smtx2">인기 상품을<br>
+          확인해 보세요</h3>
+          <p class="smtx3">가장 HOT한 중고거래 물품을 판다 마켓에서 확인해보세요</p>
+         </div> 
+      </div>
+      <!-- 구매를원하는 -->
+      <div class= "para2">
+          <div class="para-text">
+           <h5 class="smtx">Search</h5><br>
+           <h3 class="smtx2">구매를 원하는<br>
+           상품을 검색하세요</h3>
+           <p class="smtx3">구매하고 싶은 물품은 검색해서 쉽게 찾아보세요</p>
+          </div>
+      <img src="./images/Img_home_02.png" alt="para2-img" class="pimg2">  
+      </div>
+      <!-- 판매를원하는 -->
+      <div class="para3">
+        <img src="./images/Img_home_03.png" alt="para3-img" class="pimg3">
+        <div class="para-text">
+         <h5 class="smtx">Register</h5>
+         <h3 class="smtx2">판매를 원하는<br>
+         상품을 등록하세요</h3>
+         <p class="smtx3">어떤 물건이든 판매하고 싶은 상품을 쉽게 등록하세요</p>
+        </div>
+      </div>  
+
+    </section>
+    <section class="bot-banner">
+      <div class="botban-text">
+        <div class="bot-text"> 
+         믿을 수 있는<br>
+         판다마켓 중고거래
+        </div>
+        <img src="./images/Img_home_bottom.png" class="bot_img">
+      </div>
+    </section>
+  </main>
+  <!-- footer 시이작-->
+  <footer class="footer">
+    <div class ="footer-text">
+      <span>@codeit - 2024</span>
+      <div class ="policy">
+        <a href="/privacy">Privacy Policy</a>
+        <a href="/FAQ">FAQ</a>
+      </div>
+      <span class="sns-icon">
+        <img src="./images/ic_facebook.png" alt="페이스북">
+        <img src="./images/ic_twitter.png" alt="트위터">
+        <img src="./images/ic_youtube.png" alt="유튜브">
+        <img src="./images/ic_instagram.png" alt="인스타그램">
+      </span>
+    </div>
+  </footer>
+</body>
+</html>

--- a/signup.css
+++ b/signup.css
@@ -10,7 +10,12 @@ body{
 }
 
 
-
+@media (max-width: 767px) and (min-width: 375px) {
+  body {
+    width: calc(100% - 32px);
+    padding: 0 16px;
+  }
+}
 
 .signup-page {
   width: 80%;
@@ -26,13 +31,15 @@ body{
   gap: 10px;
   padding: 24px 0;
   font-size: 16px;
+  width: 100%;
 
 }
 
 .loginimg {
-  width: 396px;
-  height: 132px;
+  width: auto;
+  height: 100%;
   margin: 0 auto 20px;
+  max-width: 100%;
 }
 
 .loginform {
@@ -78,6 +85,7 @@ body{
   background-color: #f3f4f6;
   outline: none;
   gap: 10px;
+  max-width: 100%;
 }
 
 .pswdform {

--- a/signup.html
+++ b/signup.html
@@ -9,7 +9,7 @@
 <body>
   <div class="signup-page">
     <div class="text-para">
-     <img src="../images/logo.png" alt=loginimg class="loginimg">
+     <img src="./images/logo.png" alt=loginimg class="loginimg">
      <form class="loginform">
       <!-- 이메일 적는 곳 시작-->
       <label class="emailform">
@@ -38,10 +38,10 @@
       <span>간편 로그인 하기</span>
       <div class="el-icon">
         <a href="https://www.google.com">
-          <img src="../images/Component 2.png">
+          <img src="./images/Component 2.png">
         </a>
         <a href="https://www.kakaocorp.com/page">
-          <img src="../images/Component 3.png">
+          <img src="./images/Component 3.png">
         </a>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -1,11 +1,41 @@
+body {
+  margin: 0;
+}
+
+/* PC ver*/
+@media (min-width: 1200px) {
+  .container {
+    width:50%;
+
+  }
+/*  Tablet ver */
+@media (max-width: 1199px) and (min-width: 768px) {
+  body {
+    width: 70%;
+  }
+  .header {
+    padding: 0 24px;
+  }
+}
+/*  Mobile ver */
+@media (max-width: 767px) and (max-width: 375px) {
+  body {
+    width:90%;
+  }
+  .header {
+    padding: 0 16px;
+  }
+}
+
+}
 .header {
   display: flex;
   justify-content: space-between;
   width: 100%;
-  height: 70px;
+  height: 50px;
   background-color: white;
   border-bottom: 1px solid gray;
-  position: fixed;
+  position: sticky;
   align-items: center;
   top: 0;
   left: 0;
@@ -17,7 +47,7 @@
   width: 153px;
   height: 51px;
   margin: 20px;
-  padding: 20px;
+  padding: 0 20px;
   cursor: pointer;
 }
 
@@ -56,20 +86,30 @@
   align-items: center;
   gap: 32px;
   max-width: fit-content;
-
-
 }
 
-.banner-text{
+.banner_text{
   font-weight: 500;
   font-size: 2rem;
   line-height: 56px;
 }
 
-.morebtn {
-  display: inline-block;
+.more_btn{
+  display:inline;
+}
+
+.showmorebtn {
+  background-color: #3692ff;
+  gap: 10px;
+  border-radius: 40px;
+  display: block;
   padding: 10px;
-  width: 70%;;
+  width: 110%;
+  height: 30px;
+  color: #f9fafb;
+  font-size: 20px;
+  line-height: 32px;
+  text-align: center;
 }
 
 .smtx{
@@ -136,15 +176,6 @@ margin: 0;
   flex-direction: column;
 
 }
-
-
-@media (min-width: 1920px) {
-  .nav-bar{
-    
-  }
-}
-
-
 
 .first-p{
   width: 1920px;


### PR DESCRIPTION
## 요구사항

### 기본

랜딩 페이지

- [x]  Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

로그인, 회원가입 페이지 공통

- [x]  Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

### 심화

- [ ] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [ ] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [ ] 주소와 이미지는 자유롭게 설정하세요.

## 주요 변경사항

- 저번에 스프린트1미션파일이 사라졌던 것을 다시 PR했습니다.
- 

## 스크린샷

![image](이미지url)

[성5-sprint-mission3.netlify.app](https://seong5-sprint-mission3.netlify.app/)

## 멘토에게

- 구현을 다 했다고 생각하는데 뭔가 제대로 되지 않은 것 같은 느낌이 있습니다...
- 
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
